### PR TITLE
Midi files with two identical notes at the same time no longer try to play both notes

### DIFF
--- a/public/changelog.txt
+++ b/public/changelog.txt
@@ -1,5 +1,8 @@
 PixelWalker copy bot changelog
 
+2025-07-24 Version 1.5.1
+- Website: Midi files with two identical notes at the same time no longer try to play both notes.
+
 2025-07-19 Version 1.5.0
 - Bot: Added command ".edit id find_id replace_id" - edits selected block ids from "find_id" to "replace_id".
 - Bot: .move mode now does not get disabled anymore when new area is selected.

--- a/src/service/MidiImporterService.ts
+++ b/src/service/MidiImporterService.ts
@@ -160,7 +160,10 @@ function processMidiFile(midi: Midi): { [distance: number]: { type: string; note
             console.warn(`Block type conflict at distance ${distance}`)
             return
           }
-          entry.notes.push(note.midi - 21)
+          // Only push if it doesn't already exist at that point. Prevents 2 of the same note at the same block.
+          if (entry.notes.indexOf(note.midi - 21) === -1) {
+            entry.notes.push(note.midi - 21)
+          }
         }
       })
     } else {


### PR DESCRIPTION
Midi files with two identical notes at the same time no longer try to play both notes.

For example:
at 5 seconds,
31, 22, 53, 16, 53, and 55 are played.

Normally this is fine if there are less than 5 notes, since PW filters duplicate notes.
However, when there is more than 5, the bot allows for moving of notes onto the block below. This causes it to appear in the world was 2 note blocks `31, 22, 53, 16` and `55` instead of `31, 22, 53, 16, 55`

This fixes that to appear as `31, 22, 53, 16, 55`